### PR TITLE
Fix keyword conflict

### DIFF
--- a/sdcard/snippets/golang_snippets.lua
+++ b/sdcard/snippets/golang_snippets.lua
@@ -6,15 +6,15 @@ function golang_snippets.append()
     keybow.text("append(slice, value)")
 end
 
-function golang_snippets.break()
+function golang_snippets.break_keyword()
     keybow.text("break")
 end
 
-function golang_snippets.continue()
+function golang_snippets.continue_keyword()
     keybow.text("continue")
 end
 
-function golang_snippets.defer()
+function golang_snippets.defer_keyword()
     keybow.text("defer")
 end
 


### PR DESCRIPTION
Renaming a function name 'break' that conflicted with the lua keyword 'break', according to the lua linter.