### PR TITLE
Adds support for 3-key Keybow mini

### DIFF
--- a/sdcard/keybow.lua
+++ b/sdcard/keybow.lua
@@ -215,3 +215,24 @@ end
 function keybow.release_key(key)
     keybow.set_key(key, false)
 end
+
+-- Keybow Mini
+
+function keybow.use_mini()
+    keybow.set_pixel = function(x, r, g, b)
+	leds = {[0] = 3, [1] = 6, [2] = 9}
+	x = leds[x]
+	if x ~= nil then
+            keybow_set_pixel(x, r, g, b)
+        end
+    end
+    _G.handle_key_00 = function(pressed)
+        handle_minikey_00(pressed)
+    end
+    _G.handle_key_03 = function(pressed)
+        handle_minikey_01(pressed)
+    end
+    _G.handle_key_06 = function(pressed)
+        handle_minikey_02(pressed)
+    end
+end

--- a/sdcard/layouts/mini.lua
+++ b/sdcard/layouts/mini.lua
@@ -1,0 +1,36 @@
+require "keybow"
+
+function setup()
+    keybow.use_mini()
+    keybow.auto_lights(false)
+    keybow.clear_lights()
+end
+
+-- MINI Key mappings --
+
+function handle_minikey_00(pressed)
+    keybow.set_key("0", pressed)
+    if pressed then
+        keybow.set_pixel(0, 255, 0, 0)
+    else
+        keybow.set_pixel(0, 0, 0, 0)
+    end
+end
+
+function handle_minikey_01(pressed)
+    keybow.set_key("1", pressed)
+    if pressed then
+        keybow.set_pixel(1, 0, 255, 0)
+    else
+        keybow.set_pixel(1, 0, 0, 0)
+    end
+end
+
+function handle_minikey_02(pressed)
+    keybow.set_key("2", pressed)
+    if pressed then
+        keybow.set_pixel(2, 0, 0, 255)
+    else
+        keybow.set_pixel(2, 0, 0, 0)
+    end
+end


### PR DESCRIPTION
This introduces a Lua-only function which monkey-patches the relevant keybow key hooks to add `handle_minikey_00`, `handle_minikey_01` and `handle_minikey_02`. These behave just like regular keybow key handlers.

It also monkey-patches the LED function to remap mini keys 0, 1 and 2 to LED indexes 3, 6 and 9.