### PR TITLE
Unicode Character Input

### DIFF
--- a/sdcard/snippets/linux_snippets.lua
+++ b/sdcard/snippets/linux_snippets.lua
@@ -93,3 +93,21 @@ function linux_snippets.u_open_new_instance(place)
     -- opens new instance of app in Ubuntu Gnome's sidebar at the place number specified in 'place', 'place' must be a string!
     modifier(place, keybow.LEFT_META, keybow.LEFT_SHIFT)
 end
+
+-- Unicode input --
+
+function linux_snippets.unicode(code)
+    modifier("u", keybow.LEFT_CTRL, keybow.LEFT_SHIFT)
+
+    if code <= 0xffff then
+        for i = 3, 0, -1 do
+            keybow.tap_key(string.sub("0123456789abcdef", ((code >> (i * 4)) & 0x0f) + 1, ((code >> (i * 4)) & 0x0f) + 1))
+        end
+    else
+        for i = 4, 0, -1 do
+            keybow.tap_key(string.sub("0123456789abcdef", ((code >> (i * 4)) & 0x0f) + 1, ((code >> (i * 4)) & 0x0f) + 1))
+        end
+    end
+
+    keybow.tap_enter()
+end

--- a/sdcard/snippets/mac_snippets.lua
+++ b/sdcard/snippets/mac_snippets.lua
@@ -166,3 +166,22 @@ end
 function mac_snippets.reply_mail()
 	modifier("r", keybow.LEFT_META)
 end
+
+-- Unicode input --
+
+function mac_snippets.unicode(code)
+    keybow.set_modifier(keybow.LEFT_ALT, keybow.KEY_DOWN)
+
+    if code <= 0xffff then
+        for i = 3, 0, -1 do
+            keybow.tap_key(string.sub("0123456789abcdef", ((code >> (i * 4)) & 0x0f) + 1, ((code >> (i * 4)) & 0x0f) + 1))
+        end
+    else
+        code = (((code - 0x10000) & 0x3ff) | 0xdc00) | (((((code - 0x10000) >> 10) & 0x3ff) | 0xd800) << 16)
+        for i = 7, 0, -1 do
+            keybow.tap_key(string.sub("0123456789abcdef", ((code >> (i * 4)) & 0x0f) + 1, ((code >> (i * 4)) & 0x0f) + 1))
+        end
+    end
+
+    keybow.set_modifier(keybow.LEFT_ALT, keybow.KEY_UP)
+end

--- a/sdcard/snippets/win_snippets.lua
+++ b/sdcard/snippets/win_snippets.lua
@@ -1,4 +1,5 @@
 require "keybow"
+require "snippets/morekeys"
 
 win_snippets = {}
 
@@ -141,4 +142,23 @@ end
 
 function win_snippets.reply_mail()
 	modifier("r", keybow.LEFT_CTRL)
+end
+
+-- Unicode input --
+
+function win_snippets.unicode(code)
+    keybow.set_modifier(keybow.LEFT_ALT, keybow.KEY_DOWN)
+    keybow.tap_key(keybow.KPPLUS)
+
+    if code <= 0xffff then
+        for i = 3, 0, -1 do
+            keybow.tap_key(string.sub("0123456789abcdef", ((code >> (i * 4)) & 0x0f) + 1, ((code >> (i * 4)) & 0x0f) + 1))
+        end
+    else
+        for i = 4, 0, -1 do
+            keybow.tap_key(string.sub("0123456789abcdef", ((code >> (i * 4)) & 0x0f) + 1, ((code >> (i * 4)) & 0x0f) + 1))
+        end
+    end
+
+    keybow.set_modifier(keybow.LEFT_ALT, keybow.KEY_UP)
 end


### PR DESCRIPTION
Possible solution to #32

This adds snippets for Linux, macOS and Windows that allow the Keybow to input Unicode characters. The snippets use OS-specific keyboard shortcuts, some of which rely on certain system configurations so this feels a bit hack-ish. Hopefully someone can come up with a more user-friendly method.

On macOS the user must be using Unicode Hex Input which can be configured under [System Preferences -> Keyboard -> Input Sources -> + -> Others -> Unicode Hex Input]. The user then has to switch to that input method every time they want to type a Unicode character.

On Windows a registry entry needs to be added under [HKEY_Current_User -> Control Panel -> Input Method]. "EnableHexNumpad" of type string (REG_SZ) needs to be set to 1. The system also has to be rebooted before this method works.

This has been tested on Ubuntu 18.04 LTS, macOS Mojave and Windows 10