### PR TITLE
Tear down all gadgets

### DIFF
--- a/keybow/teardown.sh
+++ b/keybow/teardown.sh
@@ -6,6 +6,7 @@ echo "" > $GADGETDIR/UDC
 rmdir $GADGETDIR/configs/*/strings/*
 rm -f $GADGETDIR/configs/*/keyboard
 rm -f $GADGETDIR/configs/*/midi
+rm -f $GADGETDIR/configs/*/*
 rmdir $GADGETDIR/configs/*
 rmdir $GADGETDIR/functions/*
 rmdir $GADGETDIR/strings/*


### PR DESCRIPTION
The keybow binary sets up more gadgets than the teardown script removes, this change removes all the gadgets that are set up.