### PR TITLE
Ignore additional config.h file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ bcm2835-*/doc/Doxyfile
 bcm2835-*/doc/doxyfile.stamp
 bcm2835-*/doc/html/
 bcm2835-*/config.h
+bcm2835-*/config.h.in~
 bcm2835-*/build
 libserialport/build
 libusbgx/build


### PR DESCRIPTION
This one showed up as I was playing in the repo.  I think it's from running autoreconf twice or something.  Ignore it, anywho.