### PR TITLE
Adding Key Pad Buttons

### DIFF
--- a/sdcard/keybow.lua
+++ b/sdcard/keybow.lua
@@ -60,6 +60,26 @@ keybow.F24 = 0x73
 keybow.KEY_DOWN = true
 keybow.KEY_UP = false
 
+-- Key Pad 
+
+keybow.KPSLASH = 0x54
+keybow.KPASTERISK = 0x55
+keybow.KPMINUS = 0x56
+keybow.KPPLUS = 0x57
+keybow.KPENTER = 0x58
+keybow.KP1 = 0x59
+keybow.KP2 = 0x5a
+keybow.KP3 = 0x5b
+keybow.KP4 = 0x5c
+keybow.KP5 = 0x5d
+keybow.KP6 = 0x5e
+keybow.KP7 = 0x5f
+keybow.KP8 = 0x60
+keybow.KP9 = 0x61
+keybow.KP0 = 0x62
+keybow.KPDOT = 0x63
+keybow.KPEQUAL = 0x67
+
 keybow.MEDIA_NEXT = 0
 keybow.MEDIA_PREV = 1
 keybow.MEDIA_STOP = 2

--- a/sdcard/keys.lua
+++ b/sdcard/keys.lua
@@ -1,5 +1,6 @@
 require "keybow"
-require "layouts/default" -- Numberpad
+-- require "layouts/default" -- Numberpad
+require "layouts/sl_hyperkey" -- My Custom Numberpad
 
 -- Custom layouts (uncomment to enable) --
 

--- a/sdcard/layouts/sl_hyperkey.lua
+++ b/sdcard/layouts/sl_hyperkey.lua
@@ -1,0 +1,51 @@
+require "keybow"
+
+-- Key mappings --
+
+function handle_key_00(pressed)
+    keybow.set_key(keybow.KP0, pressed)
+end
+
+function handle_key_01(pressed)
+    keybow.set_key(keybow.KP1, pressed)
+end
+
+function handle_key_02(pressed)
+    keybow.set_key(keybow.KP2, pressed)
+end
+
+function handle_key_03(pressed)
+    keybow.set_key(keybow.KP3, pressed)
+end
+
+function handle_key_04(pressed)
+    keybow.set_key(keybow.KP4, pressed)
+end
+
+function handle_key_05(pressed)
+    keybow.set_key(keybow.KP5, pressed)
+end
+
+function handle_key_06(pressed)
+    keybow.set_key(keybow.KP6, pressed)
+end
+
+function handle_key_07(pressed)
+    keybow.set_key(keybow.KP7, pressed)
+end
+
+function handle_key_08(pressed)
+    keybow.set_key(keybow.KP8, pressed)
+end
+
+function handle_key_09(pressed)
+    keybow.set_key(keybow.KP9, pressed)
+end
+
+function handle_key_10(pressed)
+    keybow.set_key(keybow.KPDOT, pressed)
+end
+
+function handle_key_11(pressed)
+    keybow.set_key(keybow.KPEQUAL, pressed)
+end


### PR DESCRIPTION
These handy buttons are differentiated as inputs from the same numbers and symbols typed on the regular keyboard.

I use these with Keyboard Maestro on the mac and don't have to worry about overlapping uses with keys on my regular keyboard. Figured why not throw it in.

I added a comment explaining what that section is. People are learning, so it's just in an effort to help explain. If you can think of a better comment, go for it.